### PR TITLE
fix: intall Express and BodyParser types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,9 @@
   "dependencies": {
     "body-parser": "^1.20.3",
     "express": "^4.21.2"
+  },
+  "devDependencies": {
+    "@types/body-parser": "^1.19.5",
+    "@types/express": "^5.0.0"
   }
 }


### PR DESCRIPTION
Fixing another thing @choir241 and I forgot 😅
We forgot to install types for Express and Body-Parser. I realized this error after running `npm install` without them.

The errors I had before:
![image](https://github.com/user-attachments/assets/4be0ec90-4116-463f-9fef-cbeb313b8ad1)

Post intalling types:
![image](https://github.com/user-attachments/assets/58b5fe4d-0d88-4b2e-8f6a-95824d703b18)
