### PR TITLE
Menu Item Card component

### DIFF
--- a/client/src/components/MenuCard.tsx
+++ b/client/src/components/MenuCard.tsx
@@ -1,0 +1,36 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function MenuCard({
+  menuName,
+  menuDescription,
+  menuPrice,
+  image,
+  imageAlt,
+  onClickTrigger,
+}: {
+  menuName: string;
+  menuDescription: string;
+  menuPrice: string;
+  onClickTrigger: () => void;
+  image?: string;
+  imageAlt?: string;
+}) {
+  return (
+    <Card onClick={()=>onClickTrigger()} className="w-60 hover:cursor-pointer hover:bg-red-50 m-2">
+      {image && imageAlt && <CardHeader>
+        <img src={image} alt={imageAlt}/>
+      </CardHeader>}
+      <CardContent className="text-center">
+        <CardTitle className="mb-2">{menuName}</CardTitle>
+        <CardDescription className="mb-6">{menuDescription}</CardDescription>
+        <span className="font-semibold">{menuPrice}</span>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -1,0 +1,68 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn("flex flex-col gap-1.5 px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6", className)}
+      {...props}
+    />
+  )
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
- download shadcn card component
- add default to menu card component styling
- add dynamic parameters to render dynamic menu item content
- test onclick event to trigger passed function logic

## menu item card component default states
![Screenshot (114)](https://github.com/user-attachments/assets/8140f18a-71f0-425f-af7b-e982de095feb)
## menu item card component on hover states
![Screenshot (115)](https://github.com/user-attachments/assets/4365cd02-8fb7-44b4-8bbb-2dd7851e695d)
add logic to account for missing image and image alt arguments