### PR TITLE
Fix get be working with node 23.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "name": "yes-chef",
   "version": "0.0.0",
   "scripts": {
-    "start": "tsc && node dist/app.js",
+    "start": "node server/app.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon --watch *.ts --ext .ts,.js --ignore node_modules/* --ignore dist/* --exec node --loader ts-node/esm app.ts"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "start": "node server/app.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon --watch *.ts --ext .ts,.js --ignore node_modules/* --ignore dist/* --exec node --loader ts-node/esm app.ts"
+    "dev": "node --watch server/app.ts"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.0.9",

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { SERVER, DB_Connect } from './config/config.js';
+import { SERVER, DB_Connect } from '../config/config.ts';
 
 const PORT = SERVER.SERVER_PORT;
 async function startServer() {


### PR DESCRIPTION
## Fixes BE not working

## Purpose

What existing problem does it solve?
The BE code was not working for @LodenH16, @Yassahr, and @Antosha9108 
## Code Changes Descripton

Update config and import to use Node 23.9.0's native ability to run Typescript

## Steps to Reproduce or Test

How to demonstrate that the pull request is functional. For example: the exact commands to be run and their output.
- ensure `npm start` on `main` branch produces errors and does not work.
- ensure `npm start` on `fix-get-BE-working-with-node-23.9.0` does work and connects to database

## Image or GIF of Expexted Behavior
Broken `npm start`
![image](https://github.com/user-attachments/assets/c27d4968-5237-4388-ae4e-1363a1216045)

Working `npm start`
![image](https://github.com/user-attachments/assets/f2dde1e4-1bf2-4327-b75a-ff43ac9bddbb)
