### PR TITLE
Ccs 74 feat add kitchen card component

### DIFF
--- a/client/src/components/KitchenCard.tsx
+++ b/client/src/components/KitchenCard.tsx
@@ -2,13 +2,36 @@ import { Card, CardHeader, CardFooter, CardTitle, CardContent } from "@/componen
 import { Button } from "./ui/button"
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell, TableCaption } from "@/components/ui/table"
 import { ITicket } from "../models/Ticket"
+import { useEffect, useState } from "react"
 
 
 export default function KitchenCard({ ticket }: { ticket: ITicket }) {
+    const headerFooterColorOptions = {
+        "Unstarted": "bg-red-300",
+        "In Progress": "bg-yellow-300",
+        "Completed": "bg-green-300"
+    }
+    const [headerFooterColor, setHeaderFooterColor] = useState(headerFooterColorOptions[ticket.status])
+    useEffect(() => {
+        switch (ticket.status) {
+            case "Unstarted":
+                setHeaderFooterColor(headerFooterColorOptions["Unstarted"]);
+                break;
+            case "In Progress":
+                setHeaderFooterColor(headerFooterColorOptions["In Progress"])
+                break;
+            case "Completed":
+                setHeaderFooterColor(headerFooterColorOptions["Completed"]);
+                break;
+            default:
+                setHeaderFooterColor(headerFooterColorOptions["Unstarted"]);
+                break;
+        }
+    }, [ticket.status])
 
     return (
         <Card className="size-max h-fit max-h-fit py-0">
-            <CardHeader className="rounded-t-xl py-3 flex flex-row justify-between bg-amber-300">
+            <CardHeader className={"rounded-t-xl py-3 flex flex-row justify-between " + headerFooterColor}>
                 <CardTitle className="w-max">{`#${ticket.ticket_number}`}</CardTitle>
                 <CardTitle className="w-max">{`${ticket.ordered_at.getHours()}:${ticket.ordered_at.getMinutes()}`}</CardTitle>
             </CardHeader>
@@ -29,7 +52,7 @@ export default function KitchenCard({ ticket }: { ticket: ITicket }) {
                 </Table>
                 <Button> Change Status</Button>
             </CardContent>
-            <CardFooter className="rounded-b-xl py-3 bg-amber-300 justify-center">
+            <CardFooter className={"rounded-b-xl py-3 justify-center " + headerFooterColor}>
                 <CardTitle className="text-center">{ticket.status}</CardTitle>
             </CardFooter>
         </Card>

--- a/client/src/components/KitchenCard.tsx
+++ b/client/src/components/KitchenCard.tsx
@@ -1,8 +1,9 @@
 import { Card, CardHeader, CardFooter, CardTitle, CardContent } from "@/components/ui/card"
 import { Button } from "./ui/button"
-import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell, TableCaption } from "@/components/ui/table"
-import { ITicket } from "../models/Ticket"
-import { useEffect, useState } from "react"
+import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table"
+import { ITicket } from "@/models/Ticket"
+import { IMenu } from "@/models/Menu"
+import { useEffect, useState, Fragment } from "react"
 
 
 export default function KitchenCard({ ticket }: { ticket: ITicket }) {
@@ -62,6 +63,21 @@ export default function KitchenCard({ ticket }: { ticket: ITicket }) {
         }
     };
 
+    // get categories of items
+    let menuItemCategories: string[] = []
+    for (let item of ticket.menu_items) {
+        if (!menuItemCategories.includes(item.category)) {
+            menuItemCategories.push(item.category)
+        }
+    }
+    menuItemCategories = menuItemCategories.sort()
+
+    // sort menu items by categories
+    let sortedMenuItems: { [key: string]: IMenu[] } = {}
+    for (let category of menuItemCategories) {
+        sortedMenuItems[category] = ticket.menu_items.filter((item) => item.category === category)
+    }
+
     return (
         <Card className="size-max h-fit max-h-fit py-0">
             <CardHeader className={"rounded-t-xl py-3 flex flex-row justify-between " + headerFooterColor}>
@@ -77,12 +93,23 @@ export default function KitchenCard({ ticket }: { ticket: ITicket }) {
                         </TableRow>
                     </TableHeader>
                     <TableBody>
-                        {ticket.menu_items.map((item) => (
-                            <TableRow key={item._id}>
-                                <TableCell>{item.quantity}</TableCell>
-                                <TableCell className="text-right">{item.name}</TableCell>
-                            </TableRow>
-                        ))}
+                        {
+                            Object.keys(sortedMenuItems).map((category) => {
+                                return (
+                                    <Fragment key={category}>
+                                        <TableRow>
+                                            <TableCell colSpan={2} className="font-bold bg-gray-200 py-0">{category}</TableCell>
+                                        </TableRow>
+                                        {sortedMenuItems[category].map((item: any) => (
+                                            <TableRow key={item._id}>
+                                                <TableCell>{item.quantity}</TableCell>
+                                                <TableCell className="text-right">{item.name}</TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </Fragment>
+                                )
+                            })
+                        }
                     </TableBody>
                 </Table>
                 {ticket.status !== "Completed" && <Button className={buttonColor} onClick={() => handleStatusChange()}>{buttonText}</Button>}

--- a/client/src/components/KitchenCard.tsx
+++ b/client/src/components/KitchenCard.tsx
@@ -52,11 +52,11 @@ export default function KitchenCard({ ticket }: { ticket: ITicket }) {
         switch (ticket.status) {
             case "Unstarted":
                 // placeholder to update ticket status
-                console.log(`changining status of ticket ${ticket.ticket_number} to 'In Progress'`)
+                console.log(`changing status of ticket ${ticket.ticket_number} to 'In Progress'`)
                 break;
             case "In Progress":
                 // placeholder to update ticket status
-                console.log(`changining status of ticket ${ticket.ticket_number} to 'Completed'`)
+                console.log(`changing status of ticket ${ticket.ticket_number} to 'Completed'`)
                 break;
             default:
                 break;

--- a/client/src/components/KitchenCard.tsx
+++ b/client/src/components/KitchenCard.tsx
@@ -5,17 +5,18 @@ import { ITicket } from "../models/Ticket"
 
 
 export default function KitchenCard({ ticket }: { ticket: ITicket }) {
+
     return (
-        <Card className="w-max h-max py-0">
+        <Card className="size-max h-fit max-h-fit py-0">
             <CardHeader className="rounded-t-xl py-3 flex flex-row justify-between bg-amber-300">
                 <CardTitle className="w-max">{`#${ticket.ticket_number}`}</CardTitle>
                 <CardTitle className="w-max">{`${ticket.ordered_at.getHours()}:${ticket.ordered_at.getMinutes()}`}</CardTitle>
             </CardHeader>
-            <CardContent className="px-1">
+            <CardContent className="px-2">
                 <Table>
                     <TableHeader>
                         <TableHead>QTY</TableHead>
-                        <TableHead>Menu Item</TableHead>
+                        <TableHead className="text-right">Menu Item</TableHead>
                     </TableHeader>
                     <TableBody>
                         {ticket.menu_items.map((item) => (

--- a/client/src/components/KitchenCard.tsx
+++ b/client/src/components/KitchenCard.tsx
@@ -1,0 +1,36 @@
+import { Card, CardHeader, CardFooter, CardTitle, CardContent } from "@/components/ui/card"
+import { Button } from "./ui/button"
+import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell, TableCaption } from "@/components/ui/table"
+import { ITicket } from "../models/Ticket"
+
+
+export default function KitchenCard({ ticket }: { ticket: ITicket }) {
+    return (
+        <Card className="w-max h-max py-0">
+            <CardHeader className="rounded-t-xl py-3 flex flex-row justify-between bg-amber-300">
+                <CardTitle className="w-max">{`#${ticket.ticket_number}`}</CardTitle>
+                <CardTitle className="w-max">{`${ticket.ordered_at.getHours()}:${ticket.ordered_at.getMinutes()}`}</CardTitle>
+            </CardHeader>
+            <CardContent className="px-1">
+                <Table>
+                    <TableHeader>
+                        <TableHead>QTY</TableHead>
+                        <TableHead>Menu Item</TableHead>
+                    </TableHeader>
+                    <TableBody>
+                        {ticket.menu_items.map((item) => (
+                            <TableRow key={item._id}>
+                                <TableCell>{item.quantity}</TableCell>
+                                <TableCell className="text-right">{item.name}</TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+                <Button> Change Status</Button>
+            </CardContent>
+            <CardFooter className="rounded-b-xl py-3 bg-amber-300 justify-center">
+                <CardTitle className="text-center">{ticket.status}</CardTitle>
+            </CardFooter>
+        </Card>
+    )
+}

--- a/client/src/components/KitchenCard.tsx
+++ b/client/src/components/KitchenCard.tsx
@@ -6,10 +6,15 @@ import { useEffect, useState } from "react"
 
 
 export default function KitchenCard({ ticket }: { ticket: ITicket }) {
-    const headerFooterColorOptions = {
+    const ticketStatusColors = {
         "Unstarted": "bg-red-300",
         "In Progress": "bg-yellow-300",
         "Completed": "bg-green-300"
+    }
+    const headerFooterColorOptions = {
+        "Unstarted": ticketStatusColors["Unstarted"],
+        "In Progress": ticketStatusColors["In Progress"],
+        "Completed": ticketStatusColors["Completed"]
     }
     const [headerFooterColor, setHeaderFooterColor] = useState(headerFooterColorOptions[ticket.status])
     useEffect(() => {
@@ -28,6 +33,34 @@ export default function KitchenCard({ ticket }: { ticket: ITicket }) {
                 break;
         }
     }, [ticket.status])
+
+    const buttonTextOptions = {
+        "Unstarted": `Mark 'In Progress'`,
+        "In Progress": `Mark 'Completed'`,
+        "Completed": `Completed`
+    }
+    const buttonColorOptions = {
+        "Unstarted": ticketStatusColors["In Progress"],
+        "In Progress": ticketStatusColors["Completed"],
+        "Completed": "bg-green-300"
+    }
+    const buttonText = buttonTextOptions[ticket.status]
+    const buttonColor = buttonColorOptions[ticket.status]
+
+    const handleStatusChange = () => {
+        switch (ticket.status) {
+            case "Unstarted":
+                // placeholder to update ticket status
+                console.log(`changining status of ticket ${ticket.ticket_number} to 'In Progress'`)
+                break;
+            case "In Progress":
+                // placeholder to update ticket status
+                console.log(`changining status of ticket ${ticket.ticket_number} to 'Completed'`)
+                break;
+            default:
+                break;
+        }
+    };
 
     return (
         <Card className="size-max h-fit max-h-fit py-0">
@@ -52,7 +85,7 @@ export default function KitchenCard({ ticket }: { ticket: ITicket }) {
                         ))}
                     </TableBody>
                 </Table>
-                <Button> Change Status</Button>
+                {ticket.status !== "Completed" && <Button className={buttonColor} onClick={() => handleStatusChange()}>{buttonText}</Button>}
             </CardContent>
             <CardFooter className={"rounded-b-xl py-3 justify-center " + headerFooterColor}>
                 <CardTitle className="text-center">{ticket.status}</CardTitle>

--- a/client/src/components/KitchenCard.tsx
+++ b/client/src/components/KitchenCard.tsx
@@ -38,8 +38,10 @@ export default function KitchenCard({ ticket }: { ticket: ITicket }) {
             <CardContent className="px-2">
                 <Table>
                     <TableHeader>
-                        <TableHead>QTY</TableHead>
-                        <TableHead className="text-right">Menu Item</TableHead>
+                        <TableRow>
+                            <TableHead>QTY</TableHead>
+                            <TableHead className="text-right">Menu Item</TableHead>
+                        </TableRow>
                     </TableHeader>
                     <TableBody>
                         {ticket.menu_items.map((item) => (

--- a/client/src/models/Ticket.ts
+++ b/client/src/models/Ticket.ts
@@ -1,0 +1,9 @@
+import type { IMenu } from "./Menu";
+
+export interface ITicket {
+  _id: string;
+  ticket_number: number;
+  ordered_at: Date;
+  menu_items: IMenu[];
+  status: "Unstarted" | "In Progress" | "Completed";
+}

--- a/client/src/pages/Kitchen.tsx
+++ b/client/src/pages/Kitchen.tsx
@@ -1,11 +1,87 @@
 import NavBar from "@/components/NavBar"
+import KitchenCard from "@/components/KitchenCard";
+import { ITicket } from "../../../server/models/Ticket";
 
-export default function Kitchen(){
-    return(
+export default function Kitchen() {
+
+    const dummyTicketData: ITicket = [
+        {
+            _id: "uniqueTicketId",
+            ticket_number: 123,
+            ordered_at: new Date(),
+            menu_items: [
+                {
+                    _id: "uniqueMenuItemId",
+                    name: "Burger",
+                    ingredients: [
+                        {
+                            _id: "uniqueIngredientId",
+                            name: "Bun",
+                            unitCost: 1,
+                            quantity: 1,
+                            thresholdLevel: 10,
+                        },
+                        {
+                            _id: "uniqueIngredientId",
+                            name: "Patty",
+                            unitCost: 2,
+                            quantity: 1,
+                            thresholdLevel: 10,
+                        },
+                        {
+                            _id: "uniqueIngredientId",
+                            name: "Lettuce",
+                            unitCost: 1,
+                            quantity: 1,
+                            thresholdLevel: 10,
+                        },
+                        {
+                            _id: "uniqueIngredientId",
+                            name: "Tomato",
+                            unitCost: 1,
+                            quantity: 1,
+                            thresholdLevel: 10,
+                        },
+                        {
+                            _id: "uniqueIngredientId",
+                            name: "Cheese",
+                            unitCost: 1,
+                            quantity: 1,
+                            thresholdLevel: 10,
+                        },
+                        {
+                            _id: "uniqueIngredientId",
+                            name: "Onion",
+                            unitCost: 1,
+                            quantity: 1,
+                            thresholdLevel: 10,
+                        },
+                        {
+                            _id: "uniqueIngredientId",
+                            name: "Pickles",
+                            unitCost: 1,
+                            quantity: 1,
+                            thresholdLevel: 10,
+                        },
+                    ],
+                    quantity: 1,
+                    price: 10,
+                    prepTime: 15,
+                    Image: "burger.jpg",
+                    category: "Main",
+                }
+            ],
+            status: "Unstarted",
+        }
+    ];
+
+    return (
         <>
             <NavBar />
             <div className="md:ml-21"/*bump everything to the right when NavBar is fixed to the left*/>
-                <h1>Kitchen</h1>
+                {dummyTicketData.map((ticket) => (
+                    <KitchenCard key={ticket._id} ticket={ticket} />
+                ))}
             </div>
         </>
     )

--- a/client/src/pages/Kitchen.tsx
+++ b/client/src/pages/Kitchen.tsx
@@ -94,7 +94,7 @@ export default function Kitchen() {
                 prepTime: 10,
                 Image: "fries.jpg",
                 category: "Side",
-            }
+            },
         ],
         status: "Unstarted",
     }
@@ -110,9 +110,11 @@ export default function Kitchen() {
         <>
             <NavBar />
             <div className="md:ml-21"/*bump everything to the right when NavBar is fixed to the left*/>
-                {multipleDummyTickets.map((ticket) => (
-                    <KitchenCard key={ticket._id} ticket={ticket} />
-                ))}
+                <div className="flex flex-row gap-4">
+                    {multipleDummyTickets.map((ticket) => (
+                        <KitchenCard key={ticket._id} ticket={ticket} />
+                    ))}
+                </div>
             </div>
         </>
     )

--- a/client/src/pages/Kitchen.tsx
+++ b/client/src/pages/Kitchen.tsx
@@ -1,85 +1,116 @@
 import NavBar from "@/components/NavBar"
 import KitchenCard from "@/components/KitchenCard";
-import { ITicket } from "../../../server/models/Ticket";
+import { ITicket } from "../models/Ticket";
 
 export default function Kitchen() {
 
-    const dummyTicketData: ITicket = [
-        {
-            _id: "uniqueTicketId",
-            ticket_number: 123,
-            ordered_at: new Date(),
-            menu_items: [
-                {
-                    _id: "uniqueMenuItemId",
-                    name: "Burger",
-                    ingredients: [
-                        {
-                            _id: "uniqueIngredientId",
-                            name: "Bun",
-                            unitCost: 1,
-                            quantity: 1,
-                            thresholdLevel: 10,
-                        },
-                        {
-                            _id: "uniqueIngredientId",
-                            name: "Patty",
-                            unitCost: 2,
-                            quantity: 1,
-                            thresholdLevel: 10,
-                        },
-                        {
-                            _id: "uniqueIngredientId",
-                            name: "Lettuce",
-                            unitCost: 1,
-                            quantity: 1,
-                            thresholdLevel: 10,
-                        },
-                        {
-                            _id: "uniqueIngredientId",
-                            name: "Tomato",
-                            unitCost: 1,
-                            quantity: 1,
-                            thresholdLevel: 10,
-                        },
-                        {
-                            _id: "uniqueIngredientId",
-                            name: "Cheese",
-                            unitCost: 1,
-                            quantity: 1,
-                            thresholdLevel: 10,
-                        },
-                        {
-                            _id: "uniqueIngredientId",
-                            name: "Onion",
-                            unitCost: 1,
-                            quantity: 1,
-                            thresholdLevel: 10,
-                        },
-                        {
-                            _id: "uniqueIngredientId",
-                            name: "Pickles",
-                            unitCost: 1,
-                            quantity: 1,
-                            thresholdLevel: 10,
-                        },
-                    ],
-                    quantity: 1,
-                    price: 10,
-                    prepTime: 15,
-                    Image: "burger.jpg",
-                    category: "Main",
-                }
-            ],
-            status: "Unstarted",
-        }
-    ];
+    const dummyTicketData: ITicket =
+    {
+        _id: "uniqueTicketId",
+        ticket_number: 123,
+        ordered_at: new Date(),
+        menu_items: [
+            {
+                _id: "uniqueMenuItemId",
+                name: "Burger",
+                ingredients: [
+                    {
+                        _id: "uniqueIngredientId",
+                        name: "Bun",
+                        unitCost: 1,
+                        quantity: 1,
+                        thresholdLevel: 10,
+                    },
+                    {
+                        _id: "uniqueIngredientId",
+                        name: "Patty",
+                        unitCost: 2,
+                        quantity: 1,
+                        thresholdLevel: 10,
+                    },
+                    {
+                        _id: "uniqueIngredientId",
+                        name: "Lettuce",
+                        unitCost: 1,
+                        quantity: 1,
+                        thresholdLevel: 10,
+                    },
+                    {
+                        _id: "uniqueIngredientId",
+                        name: "Tomato",
+                        unitCost: 1,
+                        quantity: 1,
+                        thresholdLevel: 10,
+                    },
+                    {
+                        _id: "uniqueIngredientId",
+                        name: "Cheese",
+                        unitCost: 1,
+                        quantity: 1,
+                        thresholdLevel: 10,
+                    },
+                    {
+                        _id: "uniqueIngredientId",
+                        name: "Onion",
+                        unitCost: 1,
+                        quantity: 1,
+                        thresholdLevel: 10,
+                    },
+                    {
+                        _id: "uniqueIngredientId",
+                        name: "Pickles",
+                        unitCost: 1,
+                        quantity: 1,
+                        thresholdLevel: 10,
+                    },
+                ],
+                quantity: 1,
+                price: 10,
+                prepTime: 15,
+                Image: "burger.jpg",
+                category: "Main",
+            },
+            {
+                _id: "uniqueMenuItemId",
+                name: "Fries",
+                ingredients: [
+                    {
+                        _id: "uniqueIngredientId",
+                        name: "Potato",
+                        unitCost: 1,
+                        quantity: 1,
+                        thresholdLevel: 10,
+                    },
+                    {
+                        _id: "uniqueIngredientId",
+                        name: "Salt",
+                        unitCost: 1,
+                        quantity: 1,
+                        thresholdLevel: 10,
+                    },
+                ],
+                quantity: 1,
+                price: 5,
+                prepTime: 10,
+                Image: "fries.jpg",
+                category: "Side",
+            }
+        ],
+        status: "Unstarted",
+    }
+
+    const multipleDummyTickets = [
+        dummyTicketData,
+        dummyTicketData,
+        dummyTicketData,
+        dummyTicketData,
+    ]
 
     return (
         <>
             <NavBar />
             <div className="md:ml-21"/*bump everything to the right when NavBar is fixed to the left*/>
-                {dummyTicketData.map((ticket) => (
+                {multipleDummyTickets.map((ticket) => (
                     <KitchenCard key={ticket._id} ticket={ticket} />
                 ))}
             </div>


### PR DESCRIPTION
## #CCS-74

## Steps to Reproduce or Test
- fire up the fe
- navigate to `/kitchen`
- [ ] expect to see tickets
- ![image](https://github.com/user-attachments/assets/ac8ec4d2-aea1-4cf8-abe3-1e5577defd84)

### To Test status changes
- navigate in the code to `client/src/pages/Kitchen.tsx - line:99`
- change `status: "unstarted"` to `staus: "In Progress"`
- [ ] expect to see the tickets' status color, footer text, and button text change
- ![image](https://github.com/user-attachments/assets/ebe886e7-523b-4d41-8c7d-e5a9d5475dfa)
- change `status: "In Progress"` to `status: "Completed"`
- [ ] expect to see the tickets' status color and footer text change. The button should disappear
- ![image](https://github.com/user-attachments/assets/19f65f75-c067-4c94-91fc-cf013646337f)


## Image or GIF of Expected Behavior
see above

## Explain how the acceptance criteria are met
### Acceptance Criteria
```
This kitchen card component will be imported and used to render each kitchen order item in a loop in the list of kitchen orders.

Should include the following parameters:

list of menu items consisting of their name, quantity, time of order, status of order

ticket status

a function that triggers on click

Each kitchen order ticket should display the following

order number

time of order

each menu item separated by category

button to close/start the ticket

Set the kitchen orders card component styling with shadcn and figma

The kitchen order ticket should have a unique style for each status - unstarted, in progress, and completed
```




## Code Quality Checklist
- [x] Linted
- [ ] Prettier (or other formater) Run
- [ ] Meets WCAG 2.1 AA - validated by siteimprove