### PR TITLE
Kitchen status logic

### DIFF
--- a/client/src/models/Menu.ts
+++ b/client/src/models/Menu.ts
@@ -11,7 +11,6 @@ export interface IMenu extends Document {
     quantity: number;
     price: number;
     prepTime: number;
-    Image: string;
     cartAmt?: number;
     image: string;
 }

--- a/client/src/models/Order.ts
+++ b/client/src/models/Order.ts
@@ -1,7 +1,0 @@
-import { IMenu } from "@/models/Menu"
-
-export interface IOrder{
-    timestamp: string;
-    items: IMenu[];
-    status: string;
-}

--- a/client/src/models/Order.ts
+++ b/client/src/models/Order.ts
@@ -1,0 +1,7 @@
+import { IMenu } from "@/models/Menu"
+
+export interface IOrder{
+    timestamp: string;
+    items: IMenu[];
+    status: string;
+}

--- a/client/src/pages/Kitchen.tsx
+++ b/client/src/pages/Kitchen.tsx
@@ -2,10 +2,10 @@ import NavBar from "@/components/NavBar"
 import KitchenCard from "@/components/KitchenCard";
 import { ITicket } from "../models/Ticket";
 
-function KitchenStatus({ orders }: { orders: IOrder[] }) {
+function KitchenStatus({ orders }: { orders: ITicket[] }) {
   const sortedDate = orders.sort((a, b) => {
-    const dateA = a.timestamp.split("T")[0];
-    const dateB = b.timestamp.split("T")[0];
+    const dateA = a.ordered_at;
+    const dateB = b.ordered_at;
     if (new Date(dateA) < new Date(dateB)) {
       return 1;
     } else {
@@ -13,10 +13,10 @@ function KitchenStatus({ orders }: { orders: IOrder[] }) {
     }
   });
 
-  return sortedDate.sort((a: IOrder, b: IOrder) => {
-    if (a.status === "started") {
+  return sortedDate.sort((a: ITicket, b: ITicket) => {
+    if (a.status === "In Progress") {
       return -1;
-    } else if (a.status == "unstarted") {
+    } else if (a.status == "Unstarted") {
       return 1;
     } else {
       return 0;

--- a/client/src/pages/Kitchen.tsx
+++ b/client/src/pages/Kitchen.tsx
@@ -132,7 +132,6 @@ export default function Kitchen() {
         <>
             <NavBar />
             <div className="md:ml-21"/*bump everything to the right when NavBar is fixed to the left*/>
-              <h1>Kitchen</h1>
                 <div className="flex flex-row gap-4">
                     {multipleDummyTickets.map((ticket) => (
                         <KitchenCard key={ticket._id} ticket={ticket} />

--- a/client/src/pages/Kitchen.tsx
+++ b/client/src/pages/Kitchen.tsx
@@ -1,12 +1,37 @@
-import NavBar from "@/components/NavBar"
+import NavBar from "@/components/NavBar";
+import type { IOrder } from "@/models/Order";
 
-export default function Kitchen(){
-    return(
-        <>
-            <NavBar />
-            <div className="md:ml-21"/*bump everything to the right when NavBar is fixed to the left*/>
-                <h1>Kitchen</h1>
-            </div>
-        </>
-    )
+function KitchenStatus({ orders }: { orders: IOrder[] }) {
+  const sortedDate = orders.sort((a, b) => {
+    const dateA = a.timestamp.split("T")[0];
+    const dateB = b.timestamp.split("T")[0];
+    if (new Date(dateA) < new Date(dateB)) {
+      return 1;
+    } else {
+      return -1;
+    }
+  });
+
+  return sortedDate.sort((a: IOrder, b: IOrder) => {
+    if (a.status === "started") {
+      return -1;
+    } else if (a.status == "unstarted") {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+}
+
+export default function Kitchen() {
+  return (
+    <>
+      <NavBar />
+      <div
+        className="md:ml-21" /*bump everything to the right when NavBar is fixed to the left*/
+      >
+        <h1>Kitchen</h1>
+      </div>
+    </>
+  );
 }

--- a/server/controllers/ingredient.ts
+++ b/server/controllers/ingredient.ts
@@ -80,7 +80,7 @@ router.patch("/ingredients/updateQuantity/:id", async (req, res) => {
 
 router.put("/updateIngredientQuantity", async (req, res) => {
   try {
-    if (req.body.status === "completed") {
+    if (req.body.status === "Completed") {
       // init db connection with MongoClient
       const client = await Client_Connect();
 


### PR DESCRIPTION
![Screenshot (141)](https://github.com/user-attachments/assets/3be3d40c-33c8-4d33-96a5-0bf46f774262)

Using the kitchen orders status (unstarted, in progress) create logic to display kitchen order based on the time of each order. For example, if there are two unstarted kitchen orders, the one ordered first time-wise should be prioritized. But if there are one started kitchen order and one unstarted kitchen order, the started kitchen order should be priortized over the unstarted kitchen order.