### PR TITLE
make kitchen cards scroll horizontally

### DIFF
--- a/client/src/pages/Kitchen.tsx
+++ b/client/src/pages/Kitchen.tsx
@@ -161,7 +161,7 @@ export default function Kitchen() {
             />
           ))}
         </section>
-                <div className="flex flex-row gap-4">
+                <div className="flex flex-row gap-4 overflow-x-scroll">
                     {multipleDummyTickets.map((ticket) => (
                         <KitchenCard key={ticket._id} ticket={ticket} />
                     ))}


### PR DESCRIPTION
## #CCS-161

I tried to implement ShadCN's ScrollArea component, but couldn't get it to work. After examining the Shad Component, I discovered it works based on the `overflow-x-scroll` Tailwind class. I thought it easier and simpler to just implement this class in our existing code, rather than try to force the Shad component to work.

## Steps to Reproduce or Test
- navigate to the kitchen screen
- enable mobile view in your dev tools
- [ ] ensure the cards scroll horizontally

## Image or GIF of Expected Behavior

https://github.com/user-attachments/assets/27f616a7-42b6-46f3-91f9-9583da243572





Take the acceptance criteria from the issue and describe how the changes in the PR meets it.

Figma Design:

## Code Quality Checklist
- [x] Linted
- [ ] Prettier (or other formater) Run
- [x] Meets WCAG 2.1 AA - validated by siteimprove