### PR TITLE
Ccs 175 fix mobile styling on kitchen toggle component

### DIFF
--- a/client/src/components/KitchenMenuToggle.tsx
+++ b/client/src/components/KitchenMenuToggle.tsx
@@ -11,7 +11,7 @@ export default function KitchenMenuToggle({
   onClick: (e: string) => void;
 }) {
   return (
-    <Card className="w-1/5 p-2" onClick={()=>onClick(text)}>
+    <Card className="w-[95vw] my-1 md:w-1/5 p-2" onClick={() => onClick(text)}>
       <CardContent className="justify-between flex items-center">
         <h2>{text}</h2>
         <Button className="text-center">{icon}</Button>

--- a/client/src/pages/Kitchen.tsx
+++ b/client/src/pages/Kitchen.tsx
@@ -161,7 +161,7 @@ export default function Kitchen() {
             />
           ))}
         </section>
-                <div className="flex flex-row gap-4">
+                <div className="flex flex-row gap-4 overflow-x-scroll">
                     {multipleDummyTickets.map((ticket) => (
                         <KitchenCard key={ticket._id} ticket={ticket} />
                     ))}

--- a/client/src/pages/Kitchen.tsx
+++ b/client/src/pages/Kitchen.tsx
@@ -151,7 +151,7 @@ export default function Kitchen() {
             <div className="md:ml-21"/*bump everything to the right when NavBar is fixed to the left*/>
                      <h1>Kitchen</h1>
 
-        <section className="flex items-start justify-between">
+        <section className="flex flex-wrap md:flex-nowrap flex-col md:flex-row items-center md:items-start justify-between">
           {menuToggles.map((menu) => (
             <KitchenMenuToggle
               key={menu.text}


### PR DESCRIPTION
## #CCS-161
This follows Tailwindcss's [mobile-first design philosophy](https://tailwindcss.com/docs/responsive-design#working-mobile-first) of styling for mobile by default and adding breakpoints for larger screens.

## Steps to Reproduce or Test
- Navigate to the kitchen page
- [ ] ensure the medium screen view matches the figma
- [ ] ensure the mobile view matches the figma

## Image or GIF of Expected Behavior
Mobile View:
![image](https://github.com/user-attachments/assets/4a0fb546-1170-48e1-ad6d-4ef326aab78a)
 
desktop view:
![image](https://github.com/user-attachments/assets/9d3d96fc-266f-4928-b1d1-54129dd352a7)

## Explain how the acceptance criteria are met
Figma Designs:
![image](https://github.com/user-attachments/assets/d93eec57-c288-4a24-a5b7-9a7393dc41a0)
![image](https://github.com/user-attachments/assets/3aea4707-5ea2-4cbb-9f24-7a0335a384bd)


## Code Quality Checklist
- [x] Linted
- [ ] Prettier (or other formater) Run
- [x] Meets WCAG 2.1 AA - validated by siteimprove