### PR TITLE
Mobile menu front end display cleanup

### DIFF
--- a/client/src/components/CartTable.tsx
+++ b/client/src/components/CartTable.tsx
@@ -109,8 +109,8 @@ export function CartTable() {
   const total = subTotal + tax;
 
   return (
-    <div className="md:space-y-4 h-[400px] w-[calc(100%+16px)] flex flex-col bg-gray-50">
-    <FloatingCard className="space-y-4 h-[400px] :w-[calc(100%+16px)] flex flex-col bg-gray-50">
+    <div className="md:space-y-4 md:h-[400px] w-[calc(100%+16px)] md:w-full lg:w-80 flex flex-col bg-gray-50">
+    <FloatingCard className="space-y-4 h-[400px] flex flex-col bg-gray-50">
       <div className="flex-1 overflow-y-auto">
         <Table>
           <TableHeader>

--- a/client/src/components/CartTable.tsx
+++ b/client/src/components/CartTable.tsx
@@ -109,15 +109,15 @@ export function CartTable() {
   const total = subTotal + tax;
 
   return (
-    <div className="space-y-4 h-[400px] flex flex-col bg-gray-50">
-    <FloatingCard className="space-y-4 h-[400px] flex flex-col bg-gray-50">
+    <div className="md:space-y-4 h-[400px] w-[calc(100%+16px)] flex flex-col bg-gray-50">
+    <FloatingCard className="space-y-4 h-[400px] :w-[calc(100%+16px)] flex flex-col bg-gray-50">
       <div className="flex-1 overflow-y-auto">
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Actions</TableHead>
-              <TableHead>Amount</TableHead>
-              <TableHead>Menu Item</TableHead>
+              <TableHead></TableHead>
+              <TableHead>Qty</TableHead>
+              <TableHead>Item</TableHead>
               <TableHead>Price</TableHead>
               <TableHead className="text-right">Total</TableHead>
             </TableRow>
@@ -125,22 +125,22 @@ export function CartTable() {
           <TableBody className="">
             {cart.map((item) => (
               <TableRow key={item.id}>
-                <TableCell>
+                <TableCell >
                   <CirclePlus
-                    className="m-1 cursor-pointer hover:text-red-500"
+                    className="w-4 h-4 sm:w-5 sm:h-5 md:w-6 md:h-6 lg:w-4 lg:h-4 text-xs sm:text-md lg:text-xs m-1 cursor-pointer hover:text-red-500"
                     onClick={() => addOneToExistingItem(item.id)}
                   ></CirclePlus>
                   <CircleMinus
-                    className="m-1 cursor-pointer hover:text-red-500"
+                    className="w-4 h-4 sm:w-5 sm:h-5 md:w-6 md:h-6 lg:w-4 lg:h-4 m-1 cursor-pointer hover:text-red-500"
                     onClick={() => subtractOneFromExistingItem(item.id)}
                   ></CircleMinus>
                   <CircleX
-                    className="m-1 cursor-pointer hover:text-red-500"
+                    className="w-4 h-4 sm:w-5 sm:h-5 md:w-6 md:h-6 lg:w-4 lg:h-4 m-1 cursor-pointer hover:text-red-500"
                     onClick={() => removeFromCart(item.id)}
                   ></CircleX>
                 </TableCell>
                 <TableCell>{item.cartAmount}</TableCell>
-                <TableCell>{item.menuItem}</TableCell>
+                <TableCell className="w-12 md:w-48 lg:w-12 break-words whitespace-normal">{item.menuItem}</TableCell>
                 <TableCell>${item.price.toFixed(2)}</TableCell>
                 <TableCell className="text-right">
                   ${(item.price * item.cartAmount).toFixed(2)}

--- a/client/src/components/CategoryNav.tsx
+++ b/client/src/components/CategoryNav.tsx
@@ -20,11 +20,11 @@ function CategoryNav({ onCategoryChange, categories }: CategoryNavProps) {
     <Tabs
       value={selectedCategory}
       onValueChange={handleCategoryChange}
-      className="flex flex-1 items-center justify-center w-screen"
+      className="flex flex-1 items-center justify-center w-full"
     >
-      <TabsList>
+      <TabsList className="flex flex-wrap  bg-transparant md:bg-gray-50">
         {categories.map((category) => (
-          <TabsTrigger key={category} value={category}>
+          <TabsTrigger className="text-xs md:text-sm" key={category} value={category}>
             {category}
           </TabsTrigger>
         ))}

--- a/client/src/components/CategoryNav.tsx
+++ b/client/src/components/CategoryNav.tsx
@@ -24,7 +24,7 @@ function CategoryNav({ onCategoryChange, categories }: CategoryNavProps) {
     >
       <TabsList className="flex flex-wrap  bg-transparant md:bg-gray-50">
         {categories.map((category) => (
-          <TabsTrigger className="text-xs md:text-sm" key={category} value={category}>
+          <TabsTrigger className="md:text-sm" key={category} value={category}>
             {category}
           </TabsTrigger>
         ))}

--- a/client/src/components/FilteredMenuItems.tsx
+++ b/client/src/components/FilteredMenuItems.tsx
@@ -22,7 +22,7 @@ export default function FilteredMenuItems({ selectedCategory }: { selectedCatego
     };
 
     return (
-        <div className="flex-1 grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 gap-6">
+        <div className="flex-1 grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 gap-6 ">
             {filteredMenuItems.map((item: IMenu) => (
                 <MenuCard
                     key={item._id}

--- a/client/src/components/FilteredMenuItems.tsx
+++ b/client/src/components/FilteredMenuItems.tsx
@@ -22,7 +22,7 @@ export default function FilteredMenuItems({ selectedCategory }: { selectedCatego
     };
 
     return (
-        <div className="flex-1 grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 gap-6 ">
+        <div className="flex-1 grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 gap-6 place-items-center md:place-items-stretch">
             {filteredMenuItems.map((item: IMenu) => (
                 <MenuCard
                     key={item._id}

--- a/client/src/components/MenuCard.tsx
+++ b/client/src/components/MenuCard.tsx
@@ -23,13 +23,13 @@ export default function MenuCard({
   imageAlt?: string;
 }) {
   return (
-    <FloatingCard onClick={() => onClickTrigger()} className="w-38 sm:w-40 md:w-48 lg:w-56 hover:cursor-pointer hover:bg-red-50 m-4">
+    <FloatingCard onClick={() => onClickTrigger()} className="w-32 sm:w-40 md:w-48 lg:w-56 hover:cursor-pointer hover:bg-red-50 m-0 md:m-4">
       {image && imageAlt && <CardHeader>
         <img src={image} alt={imageAlt} />
       </CardHeader>}
-      <CardContent className="text-center">
+      <CardContent className="text-center px-2 md:px-6 text-sm md:text-lg">
         <CardTitle className="mb-2">{menuName}</CardTitle>
-        <CardDescription className="mb-6">{menuDescription}</CardDescription>
+        <CardDescription className="mb-6 text-sm md:text-base">{menuDescription}</CardDescription>
         <span className="font-semibold">{menuPrice}</span>
       </CardContent>
     </FloatingCard>

--- a/client/src/pages/Menu.tsx
+++ b/client/src/pages/Menu.tsx
@@ -14,7 +14,7 @@ export default function Menu() {
 
     return (
 
-        <div className="">
+        <div >
             <CategoryNav
                 onCategoryChange={setSelectedCategory}
                 categories={["Appetizers", "Pizza", "Pasta", "Entrees", "Desserts"]}

--- a/client/src/pages/Menu.tsx
+++ b/client/src/pages/Menu.tsx
@@ -19,7 +19,7 @@ export default function Menu() {
                 onCategoryChange={setSelectedCategory}
                 categories={["Appetizers", "Pizza", "Pasta", "Entrees", "Desserts"]}
             />
-            <div className="container mx-auto md:pl-24 px-4 py-8 flex flex-col lg:flex-row gap-8 ">
+            <div className="container mx-auto md:pl-24 px-0 md:px-4 py-16 md:py-8 flex flex-col lg:flex-row gap-8 ">
                 {/* Menu Items */}
                 <Suspense fallback={<LoadingMenuItems />}>
                     <FilteredMenuItems selectedCategory={selectedCategory} />


### PR DESCRIPTION
improvements:
- category nav wraps on mobile
- text wraps on item in cart
- font on menucards is responsive
- plus/minus/remove icons are responsive
- menu cards on mobile are smaller/don't overlap each other anymore

expected result:
![image](https://github.com/user-attachments/assets/8ce379eb-c29c-4590-aa96-50fdea5df69b)
![image](https://github.com/user-attachments/assets/2933764f-ceb5-48c0-8559-fc8493b86b47)
![image](https://github.com/user-attachments/assets/0228a134-5088-437c-872b-9432ebc5c8dd)
