### PR TITLE
Rich/fix navbar

### DIFF
--- a/client/src/components/FilteredMenuItems.tsx
+++ b/client/src/components/FilteredMenuItems.tsx
@@ -12,7 +12,7 @@ export default function FilteredMenuItems({ selectedCategory }: { selectedCatego
 
         addToCart({
             id: item._id,
-            menuItem: item.name,
+            menuItem: item.menuItem,
             cartAmount: 1,
             price: item.price,
             ingredients: item.ingredients,
@@ -26,11 +26,11 @@ export default function FilteredMenuItems({ selectedCategory }: { selectedCatego
             {filteredMenuItems.map((item: IMenu) => (
                 <MenuCard
                     key={item._id}
-                    menuName={item.name}
+                    menuName={item.menuItem}
                     menuDescription={item.ingredients.map((i) => i.ingredientName).join(", ")}
                     menuPrice={`$${item.price.toFixed(2)}`}
                     image={item.image}
-                    imageAlt={item.name}
+                    imageAlt={item.menuItem}
                     onClickTrigger={() => handleAddToCart(item)}
 
                 />

--- a/client/src/components/MenuEngineeringDashComponents/ItemProfitability.tsx
+++ b/client/src/components/MenuEngineeringDashComponents/ItemProfitability.tsx
@@ -27,7 +27,7 @@ export default function ItemProfitability() {
                     {menuItems.map((item: IMenu) => (
                         <ItemProfitabilityCard
                             key={item._id}
-                            menuName={item.name}
+                            menuName={item.menuItem}
                             menuDescription={item.ingredients.map((i) => i.ingredientName).join(", ")}
                             menuPrice={`$${item.price.toFixed(2)}`}
                         />

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -30,19 +30,6 @@ export default function NavBar({}) {
                         </NavigationMenuLink>
                     </NavigationMenuItem>
                     <NavigationMenuItem>
-                        <NavigationMenuLink className="bg-white text-gray-700" href="/orders" data-active={isActiveRoute("/orders")}>
-                            <ShoppingBag />
-                            Orders
-                        </NavigationMenuLink>
-                    </NavigationMenuItem>
-                    
-                    <NavigationMenuItem>
-                        <NavigationMenuLink className="bg-white text-gray-700" href="/reports" data-active={isActiveRoute("/reports")}>
-                            <Clock />
-                            Reports
-                        </NavigationMenuLink>
-                    </NavigationMenuItem>
-                    <NavigationMenuItem>
                         <NavigationMenuLink className="bg-white text-gray-700" href="/kitchen" data-active={isActiveRoute("/kitchen")}>
                             <Utensils />
                             Kitchen
@@ -52,6 +39,12 @@ export default function NavBar({}) {
                         <NavigationMenuLink className="bg-white text-gray-700" href="/inventory" data-active={isActiveRoute("/inventory")}>
                             <Clipboard />
                             Inventory
+                        </NavigationMenuLink>
+                    </NavigationMenuItem>
+                    <NavigationMenuItem>
+                        <NavigationMenuLink className="bg-white text-gray-700" href="/reports" data-active={isActiveRoute("/reports")}>
+                            <Clock />
+                            Reports
                         </NavigationMenuLink>
                     </NavigationMenuItem>
                 </NavigationMenuList>

--- a/client/src/models/Menu.ts
+++ b/client/src/models/Menu.ts
@@ -5,7 +5,7 @@ export interface IMenuIngredient {
 
 export interface IMenu {
     _id: string;
-    name: string;
+    menuItem: string;
     category: string;
     ingredients: IMenuIngredient[];
     quantity: number;

--- a/client/src/pages/Kitchen.tsx
+++ b/client/src/pages/Kitchen.tsx
@@ -11,7 +11,7 @@ import axios from "axios";
 import { ENDPOINT_URL } from "@/staticVar";
 
 export interface IRecommendation {
-  name: string;
+  menuItem: string;
   quantity: number;
   ingredients: IMenuIngredient[];
 }
@@ -94,8 +94,8 @@ export default function Kitchen() {
     // update quantity of each menu item ordered
     completedTickets.forEach((ticket: ITicket) => {
       ticket.items.forEach((menu: IMenu) => {
-        if (menuOrderQuantity.hasOwnProperty(menu.name)) {
-          menuOrderQuantity[menu.name]+=1*menu.cartAmount;
+        if (menuOrderQuantity.hasOwnProperty(menu.menuItem) && ticket.status==="completed") {
+          menuOrderQuantity[menu.menuItem]+=1*menu.cartAmount;
         }
       });
     });
@@ -118,7 +118,7 @@ export default function Kitchen() {
     }
 
     const recommendations: {
-      name: string;
+      menuItem: string;
       createdAt: Date;
       ingredients: IMenuIngredient[];
       quantity: number;
@@ -127,11 +127,11 @@ export default function Kitchen() {
     //grab the most popular menu items with their order date
     completedTickets.forEach((ticket: ITicket) => {
       ticket.items.forEach((menu: IMenu) => {
-        if (popularMenuItems.includes(menu.name)) {
+        if (popularMenuItems.includes(menu.menuItem)) {
           recommendations.push({
-            name: menu.name,
+            menuItem: menu.menuItem,
             createdAt: ticket.createdAt,
-            quantity: menuOrderQuantity[menu.name] - average,
+            quantity: menuOrderQuantity[menu.menuItem] - average,
             ingredients: menu.ingredients,
           });
         }
@@ -171,15 +171,15 @@ export default function Kitchen() {
         // check if item order time is greater than or equal to first time blcok
         // check if item order time is less than or equal to second time block
         if (
-          item.createdAt >= firstTimeBlock &&
-          item.createdAt <= secondTimeBlock
+          new Date(item.createdAt) >= firstTimeBlock &&
+          new Date(item.createdAt) <= secondTimeBlock
         ) {
           recommendationTimeBlocks[i].items.push({
-            name: item.name,
-            quantity: menuOrderQuantity[item.name] - average,
+            menuItem: item.menuItem,
+            quantity: menuOrderQuantity[item.menuItem] - average,
             ingredients: item.ingredients,
           });
-        }
+        } 
       }
     });
 
@@ -191,7 +191,7 @@ export default function Kitchen() {
           endTime: block.endTime,
           items: block.items.reduce(
             (acc: IRecommendation[], current: IRecommendation) => {
-              const findItem = acc.find((item) => item.name === current.name);
+              const findItem = acc.find((item) => item.menuItem === current.menuItem);
               if (findItem) {
                 return acc;
               }
@@ -204,6 +204,7 @@ export default function Kitchen() {
     );
 
     return removeDuplicates;
+          
   }
 
   const [toggleView, setToggleView] = useState("Open Tickets");
@@ -213,7 +214,6 @@ export default function Kitchen() {
     { text: "Closed Tickets", icon: <NotepadTextDashed /> },
     { text: "Predictions", icon: <Stars /> },
   ];
-
   return (
     <>
       <div
@@ -239,11 +239,11 @@ export default function Kitchen() {
               return menu.items.map((item) => {
                 return (
                   <RecommendationCard
-                    key={item.name}
+                    key={item.menuItem}
                     recommendation={{
                       startTime: menu.startTime,
                       endTime: menu.endTime,
-                      name: item.name,
+                      name: item.menuItem,
                       quantity: item.quantity,
                       ingredients: item.ingredients,
                     }}

--- a/client/src/pages/Reports.tsx
+++ b/client/src/pages/Reports.tsx
@@ -42,7 +42,7 @@ export default function Reports() {
                     {filteredMenuItems.map((item: IMenu) => (
                         <MenuCard
                             key={item._id}
-                            menuName={item.name}
+                            menuName={item.menuItem}
                             menuDescription={item.ingredients.map((i) => i.ingredientName).join(", ")}    
                             menuPrice={`$${item.price.toFixed(2)}`}                
                             onClickTrigger={() => renderMetrics(item)}


### PR DESCRIPTION
Removed Orders page that isn’t being used in this application right now. Made sure this also applied in the mobile phone view.

Updated the order of the links so that Kitchen is before Reports. So the order of navbar links is the following: Home, Kitchen, Inventory, Reports. This also applied for the mobile phone view.

![Screenshot (220)](https://github.com/user-attachments/assets/7b10f1bd-6a3a-4eab-87a4-fee8b56c9af7)
![Screenshot (219)](https://github.com/user-attachments/assets/62ba6f17-2b8a-4108-9bc9-a01ba41603ea)